### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete multi-character sanitization

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -7,6 +7,7 @@ const tocPlugin = require("eleventy-plugin-nesting-toc");
 const { parse } = require("node-html-parser");
 const htmlMinifier = require("html-minifier-terser");
 const pluginRss = require("@11ty/eleventy-plugin-rss");
+const sanitizeHtml = require("sanitize-html");
 
 const { headerToId, namedHeadingsFilter } = require("./src/helpers/utils");
 const {
@@ -365,8 +366,9 @@ module.exports = function (eleventyConfig) {
           function (metaInfoMatch, callout, metaData, collapse, title) {
             isCollapsable = Boolean(collapse);
             isCollapsed = collapse === "-";
-            const titleText = title.replace(/(<\/{0,1}\w+>)/, "")
-              ? title
+            const sanitizedTitle = sanitizeHtml(title, { allowedTags: [], allowedAttributes: {} }).trim();
+            const titleText = sanitizedTitle
+              ? sanitizedTitle
               : `${callout.charAt(0).toUpperCase()}${callout
                 .substring(1)
                 .toLowerCase()}`;

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "markdown-it-plantuml": "^1.4.1",
         "markdown-it-task-checkbox": "^1.0.6",
         "npm-run-all": "^4.1.5",
-        "rimraf": "^6.0.1"
+        "rimraf": "^6.0.1",
+        "sanitize-html": "^2.17.0"
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/wwha/dg-obsidian/security/code-scanning/1](https://github.com/wwha/dg-obsidian/security/code-scanning/1)

To correctly sanitize the `title` string, we should use a robust and proven sanitization library, such as `sanitize-html`, to strip any potentially dangerous HTML, especially active content like `<script>` tags and unwanted attributes. The best fix, requiring minimal code change and maximum benefit, is to import `sanitize-html` (which is widely used), and apply it to the `title` value before constructing `titleText`. This change will occur inside the anonymous function passed to `replace`, where `title` is processed for display. To implement this, add the `sanitize-html` dependency at the top of the file, use it in place of the current regex-based replacement, and ensure that the rest of the logic, including the fallback title computation, remains unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
