### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete string escaping or encoding

### DIFF
--- a/src/helpers/linkUtils.js
+++ b/src/helpers/linkUtils.js
@@ -13,7 +13,7 @@ function extractLinks(content) {
           .slice(2, -2)
           .split("|")[0]
           .replace(/.(md|markdown)\s?$/i, "")
-          .replace("\\", "")
+          .replace(/\\/g, "")
           .trim()
           .split("#")[0]
     ),
@@ -23,7 +23,7 @@ function extractLinks(content) {
           .slice(6, -1)
           .split("|")[0]
           .replace(/.(md|markdown)\s?$/i, "")
-          .replace("\\", "")
+          .replace(/\\/g, "")
           .trim()
           .split("#")[0]
     ),


### PR DESCRIPTION
Potential fix for [https://github.com/wwha/dg-obsidian/security/code-scanning/3](https://github.com/wwha/dg-obsidian/security/code-scanning/3)

To fix the problem, we need to ensure all backslashes are removed from the link strings, not just the first one. In JavaScript, the best practice is to use a regular expression with the global (`g`) flag as the first argument to `replace`. Specifically, to remove all backslashes, we should use `.replace(/\\/g, "")`. This change should be made in both locations within `extractLinks` where `.replace("\\", "")` appears: on lines 16 and 26. No other changes are required, and no external libraries are needed, as this is a standard regex. The rest of the code functionality remains unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
